### PR TITLE
Bugfix: main_v3.4 - Prevent pandas >2 from being installed

### DIFF
--- a/Dockerfile.metviewer
+++ b/Dockerfile.metviewer
@@ -136,7 +136,7 @@ RUN \
   && pip install wheel \
   && pip install python-dateutil \
   && pip install opencv-python \
-  && pip install pandas \
+  && pip install "pandas>=2.3.3,<3" \
   && echo "Install chrome for plotly/kaleido" &&\
      wget https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb &&\
      apt-get install -y ./google-chrome-stable_current_amd64.deb \


### PR DESCRIPTION
The METplus Analysis tools have not been tested/enhanced to work with pandas 3.x

@hertneky tested a dev version of METviewer 6.2 to confirm that the fix prevents the error encountered.