### PR TITLE
Bugfix: main_v3.5 - Prevent pandas >2 from being installed

### DIFF
--- a/Dockerfile.metviewer
+++ b/Dockerfile.metviewer
@@ -113,7 +113,7 @@ RUN \
       numpy \
       opencv-python \
       packaging \
-      pandas \
+      "pandas>=2.3.3,<3" \
       pint \
       plotly \
       pluggy \


### PR DESCRIPTION
Equivalent change as #56

Also apply this change to develop after this is merged.